### PR TITLE
VIH-8805 Update BookingsApiClient to 1.30.25

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BookingsApi.Client" Version="1.30.24" />
+      <PackageReference Include="BookingsApi.Client" Version="1.30.25" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.12" />
       <PackageReference Include="VideoApi.Client" Version="1.27.4" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.30.24, )",
-        "resolved": "1.30.24",
-        "contentHash": "hpiGpd+8C2vC9l/r1o5t+bGXGS7pALbIZa+DIjkqUJtRrMKHiSoZUJT5oXwPFgxWoqM703UhMDrEHGi47EttNQ==",
+        "requested": "[1.30.25, )",
+        "resolved": "1.30.25",
+        "contentHash": "M8N18DzbD2p0bN6OyBVY2K1neL/Udry48Mhlp4B/ZoTxECfAXTC0vrTsb8kF/IvF0fqfK7+BSNk/MWlY6mIAXQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "Newtonsoft.Json": "12.0.3"

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
@@ -86,8 +86,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.30.24",
-        "contentHash": "hpiGpd+8C2vC9l/r1o5t+bGXGS7pALbIZa+DIjkqUJtRrMKHiSoZUJT5oXwPFgxWoqM703UhMDrEHGi47EttNQ==",
+        "resolved": "1.30.25",
+        "contentHash": "M8N18DzbD2p0bN6OyBVY2K1neL/Udry48Mhlp4B/ZoTxECfAXTC0vrTsb8kF/IvF0fqfK7+BSNk/MWlY6mIAXQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "Newtonsoft.Json": "12.0.3"
@@ -2307,7 +2307,7 @@
         "type": "Project",
         "dependencies": {
           "BookingQueueSubscriber.Common": "1.0.0",
-          "BookingsApi.Client": "1.30.24",
+          "BookingsApi.Client": "1.30.25",
           "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
           "System.IdentityModel.Tokens.Jwt": "6.11.1",
           "VideoApi.Client": "1.27.4"

--- a/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
@@ -163,8 +163,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.30.24",
-        "contentHash": "hpiGpd+8C2vC9l/r1o5t+bGXGS7pALbIZa+DIjkqUJtRrMKHiSoZUJT5oXwPFgxWoqM703UhMDrEHGi47EttNQ==",
+        "resolved": "1.30.25",
+        "contentHash": "M8N18DzbD2p0bN6OyBVY2K1neL/Udry48Mhlp4B/ZoTxECfAXTC0vrTsb8kF/IvF0fqfK7+BSNk/MWlY6mIAXQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5",
           "Newtonsoft.Json": "12.0.3"
@@ -2246,7 +2246,7 @@
         "type": "Project",
         "dependencies": {
           "BookingQueueSubscriber.Common": "1.0.0",
-          "BookingsApi.Client": "1.30.24",
+          "BookingsApi.Client": "1.30.25",
           "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
           "System.IdentityModel.Tokens.Jwt": "6.11.1",
           "VideoApi.Client": "1.27.4"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8805


### Change description ###
Updates the BookingsApiClient to the latest version to fix a translation issue with some recently added case role groups.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
