### PR TITLE
VIH-9607 Update booking status after conference is created

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.AcceptanceTests/BookingQueueSubscriber.AcceptanceTests.csproj
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.AcceptanceTests/BookingQueueSubscriber.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.39.36" />
+    <PackageReference Include="BookingsApi.Client" Version="1.41.8" />
     <PackageReference Include="Faker.NETCore" Version="1.0.2" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />

--- a/BookingQueueSubscriber/BookingQueueSubscriber.AcceptanceTests/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.AcceptanceTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.39.36, )",
-        "resolved": "1.39.36",
-        "contentHash": "PVgSPCpPs5MTznxJl+vN10vTEMMyO0oWrZW89ghdSj3Ej7ZknwAAcBhQzfwKELF56oERvu+76q1c6I1jnVj3Hg==",
+        "requested": "[1.41.8, )",
+        "resolved": "1.41.8",
+        "contentHash": "6hxFUsxR6k64cR9iQimTTBd0d7O6J/45mZ+oyxxNfOgn/qqLhcJoI8XZLCYp10yfbOOPYSziJxEZl1xbqjorxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2245,13 +2245,13 @@
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[6.3.3, )",
-          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
-          "Newtonsoft.Json": "[13.0.1, )",
-          "VH.Core.Configuration": "[0.1.12, )"
+          "LaunchDarkly.ServerSdk": "6.3.3",
+          "Microsoft.Azure.Functions.Extensions": "1.1.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
+          "Microsoft.Extensions.Configuration.Json": "6.0.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
+          "Newtonsoft.Json": "13.0.1",
+          "VH.Core.Configuration": "0.1.12"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BookingsApi.Client" Version="1.39.36" />
+      <PackageReference Include="BookingsApi.Client" Version="1.41.8" />
       <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.3.3" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
       <PackageReference Include="NotificationApi.Client" Version="1.38.11" />

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingsApiClientFake.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingsApiClientFake.cs
@@ -1,4 +1,5 @@
 using BookingsApi.Client;
+using BookingsApi.Contract.Enums;
 using BookingsApi.Contract.Requests;
 using BookingsApi.Contract.Responses;
 using System;
@@ -526,7 +527,7 @@ namespace BookingQueueSubscriber.Services
 
         public Task UpdateBookingStatusAsync(Guid hearingId, UpdateBookingStatusRequest request)
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
 
         public Task UpdateBookingStatusAsync(Guid hearingId, UpdateBookingStatusRequest request, CancellationToken cancellationToken)
@@ -603,6 +604,55 @@ namespace BookingQueueSubscriber.Services
         {
             throw new NotImplementedException();
         }
-        
+
+        public Task<JusticeUserResponse> AllocateHearingAutomaticallyAsync(Guid hearingId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<JusticeUserResponse> AllocateHearingAutomaticallyAsync(Guid hearingId, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICollection<HearingDetailsResponse>> GetUnallocatedHearingsAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICollection<HearingDetailsResponse>> GetUnallocatedHearingsAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<HearingDetailsResponse> GetBookingStatusByIdAsync(Guid hearingId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<HearingDetailsResponse> GetBookingStatusByIdAsync(Guid hearingId, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICollection<JusticeUserResponse>> GetJusticeUserListAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ICollection<JusticeUserResponse>> GetJusticeUserListAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        Task<BookingStatus> IBookingsApiClient.GetBookingStatusByIdAsync(Guid hearingId)
+        {
+            throw new NotImplementedException();
+        }
+
+        Task<BookingStatus> IBookingsApiClient.GetBookingStatusByIdAsync(Guid hearingId, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/UserApi/UserService.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/UserApi/UserService.cs
@@ -20,7 +20,6 @@ namespace BookingQueueSubscriber.Services.UserApi
     {
         private readonly IUserApiClient _userApiClient;
         private readonly ILogger<UserService> _logger;
-        private readonly IFeatureToggles _featureToggles;
 
         public const string Representative = "Representative";
         public const string Joh = "Judicial Office Holder";
@@ -31,11 +30,10 @@ namespace BookingQueueSubscriber.Services.UserApi
         public const string StaffMember = "Staff Member";
         public const string SsprEnabled = "SSPR Enabled";
         
-        public UserService(IUserApiClient userApiClient, ILogger<UserService> logger, IFeatureToggles featureToggles)
+        public UserService(IUserApiClient userApiClient, ILogger<UserService> logger)
         {
             _userApiClient = userApiClient;
             _logger = logger;
-            _featureToggles = featureToggles;
         }
 
         public async Task<User> CreateNewUserForParticipantAsync(string firstname, string lastname, string contactEmail,
@@ -111,10 +109,6 @@ namespace BookingQueueSubscriber.Services.UserApi
                 default:
                     await AddGroup(userId, External);
                     break;
-            }
-            if (_featureToggles.SsprToggle())
-            {
-                await AddGroup(userId, SsprEnabled);
             }
         }
         private async Task<NewUserResponse> CreateNewUserInAD(string firstname, string lastname, string contactEmail, bool isTestUser)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.39.36, )",
-        "resolved": "1.39.36",
-        "contentHash": "PVgSPCpPs5MTznxJl+vN10vTEMMyO0oWrZW89ghdSj3Ej7ZknwAAcBhQzfwKELF56oERvu+76q1c6I1jnVj3Hg==",
+        "requested": "[1.41.8, )",
+        "resolved": "1.41.8",
+        "contentHash": "6hxFUsxR6k64cR9iQimTTBd0d7O6J/45mZ+oyxxNfOgn/qqLhcJoI8XZLCYp10yfbOOPYSziJxEZl1xbqjorxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1755,13 +1755,13 @@
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[6.3.3, )",
-          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
-          "Newtonsoft.Json": "[13.0.1, )",
-          "VH.Core.Configuration": "[0.1.12, )"
+          "LaunchDarkly.ServerSdk": "6.3.3",
+          "Microsoft.Azure.Functions.Extensions": "1.1.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
+          "Microsoft.Extensions.Configuration.Json": "6.0.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
+          "Newtonsoft.Json": "13.0.1",
+          "VH.Core.Configuration": "0.1.12"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/CreateAndNotifyUserHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/CreateAndNotifyUserHandlerTests.cs
@@ -77,7 +77,7 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
         }
 
         [Test]
-        public async Task should_assign_users_to_correct_group_when_request_is_valid_and_sspr_feature_is_enabled()
+        public async Task should_assign_users_to_correct_group_when_request_is_valid()
         {
             var notificationService = new Mock<INotificationService>();
             var userApiClient = new Mock<IUserApiClient>();
@@ -123,10 +123,7 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
                 });
             }
 
-            var featureToggles = new Mock<IFeatureToggles>();
-            featureToggles.Setup(x => x.SsprToggle()).Returns(true);
-            
-            var userService = new UserService(userApiClient.Object, new Mock<ILogger<UserService>>().Object, featureToggles.Object);
+            var userService = new UserService(userApiClient.Object, new Mock<ILogger<UserService>>().Object);
             var bookingsApiClient = new Mock<IBookingsApiClient>();
             var logger = new Mock<ILogger<UserCreationAndNotification>>();
 
@@ -166,116 +163,10 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
             foreach (var participant in integrationEvent.Participants)
             {
                 userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                    r.UserId == participant.LastName && 
-                    r.GroupName == UserService.SsprEnabled)));
+                    r.UserId == participant.LastName)));
             }
         }
    
-        [TestCase(false)]
-        [TestCase(true)]
-        public async Task should_assign_users_to_correct_group_when_request_is_valid_and_sspr_feature_is_toggled(bool ssprFeatureEnabled)
-        {
-            var notificationService = new Mock<INotificationService>();
-            var userApiClient = new Mock<IUserApiClient>();
-            var integrationEvent = new CreateAndNotifyUserIntegrationEvent
-            {
-                Hearing = GetHearingDto(),
-                Participants = new List<ParticipantDto>
-                {
-                    new ParticipantDto
-                    {
-                        FirstName = "Test",
-                        LastName = UserRole.Representative.ToString(),
-                        UserRole = "Representative"
-                    },
-                    new ParticipantDto
-                    {
-                        FirstName = "Test",
-                        LastName = UserRole.JudicialOfficeHolder.ToString(),
-                        UserRole = "Judicial Office Holder"
-                    },
-                    new ParticipantDto
-                    {
-                        FirstName = "Test",
-                        LastName = UserRole.StaffMember.ToString(),
-                        UserRole = "StaffMember"
-                    },
-                    new ParticipantDto
-                    {
-                        FirstName = "Test",
-                        LastName = UserRole.Individual.ToString(),
-                        UserRole = "Individual"
-                    }
-                }
-            };
-
-            foreach (var participant in integrationEvent.Participants)
-            {
-                userApiClient.Setup(x => x.CreateUserAsync(It.Is<CreateUserRequest>(r => r.LastName == participant.LastName))).ReturnsAsync(new NewUserResponse
-                {
-                    Username = "test@hmcts.net",
-                    UserId = participant.LastName,
-                    OneTimePassword = "Password"
-                });
-            }
-
-            var featureToggles = new Mock<IFeatureToggles>();
-            featureToggles.Setup(x => x.SsprToggle()).Returns(ssprFeatureEnabled);
-            
-            var userService = new UserService(userApiClient.Object, new Mock<ILogger<UserService>>().Object, featureToggles.Object);
-            var bookingsApiClient = new Mock<IBookingsApiClient>();
-            var logger = new Mock<ILogger<UserCreationAndNotification>>();
-
-            var messageHandler = (IMessageHandler)new CreateAndNotifyUserHandler(new UserCreationAndNotification(
-                notificationService.Object,
-                userService,
-                bookingsApiClient.Object,
-                logger.Object));
-
-            await messageHandler.HandleAsync(integrationEvent);
-            
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.Representative.ToString() && 
-                r.GroupName == UserService.External)));
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.Representative.ToString() && 
-                r.GroupName == UserService.VirtualRoomProfessionalUser)));
-            
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.JudicialOfficeHolder.ToString() && 
-                r.GroupName == UserService.External)));
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.JudicialOfficeHolder.ToString() && 
-                r.GroupName == UserService.JudicialOfficeHolder)));
-            
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.StaffMember.ToString() && 
-                r.GroupName == UserService.Internal)));
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.StaffMember.ToString() && 
-                r.GroupName == UserService.StaffMember)));
-            
-            userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                r.UserId == UserRole.Individual.ToString() && 
-                r.GroupName == UserService.External)));
-
-            foreach (var participant in integrationEvent.Participants)
-            {
-                if (ssprFeatureEnabled)
-                {
-                    userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                        r.UserId == participant.LastName && 
-                        r.GroupName == UserService.SsprEnabled)), Times.Once);
-                }
-                else
-                {
-                    userApiClient.Verify(x => x.AddUserToGroupAsync(It.Is<AddUserToGroupRequest>(r => 
-                        r.UserId == participant.LastName && 
-                        r.GroupName == UserService.SsprEnabled)), Times.Never);
-                }
-            }
-        }
-        
         private CreateAndNotifyUserIntegrationEvent GetIntegrationEvent()
         {
 

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/HearingReadyForVideoHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/HearingReadyForVideoHandlerTests.cs
@@ -11,33 +11,36 @@ using Moq;
 using NUnit.Framework;
 using VideoApi.Contract.Enums;
 using VideoApi.Contract.Responses;
+using BookingsApi.Contract.Requests;
 
 namespace BookingQueueSubscriber.UnitTests.MessageHandlers
 {
     public class HearingReadyForVideoHandlerTests : MessageHandlerTestBase
     {
         [Test]
-        public async Task should_call_video_api_when_request_is_valid()
+        public async Task should_call_video_and_bookings_api_when_request_is_valid()
         {
             var messageHandler = new HearingReadyForVideoHandler(VideoApiServiceMock.Object, VideoWebServiceMock.Object,
-                UserCreationAndNotificationMock.Object);
+                UserCreationAndNotificationMock.Object, BookingsApiClientMock.Object );
             VideoApiServiceMock.Setup(x => x.BookNewConferenceAsync(It.IsAny<BookNewConferenceRequest>())).ReturnsAsync(new ConferenceDetailsResponse());
          
             var integrationEvent = CreateEvent();
             await messageHandler.HandleAsync(integrationEvent);
             VideoApiServiceMock.Verify(x => x.BookNewConferenceAsync(It.IsAny<BookNewConferenceRequest>()), Times.Once);
+            BookingsApiClientMock.Verify(x => x.UpdateBookingStatusAsync(It.IsAny<Guid>(), It.IsAny<UpdateBookingStatusRequest>()), Times.Once);
         }
 
         [Test]
-        public async Task should_call_video_api_when_handle_is_called_with_explicit_interface()
+        public async Task should_call_video_and_bookings_api_when_handle_is_called_with_explicit_interface()
         {
             var messageHandler = (IMessageHandler) new HearingReadyForVideoHandler(VideoApiServiceMock.Object,
-                VideoWebServiceMock.Object, UserCreationAndNotificationMock.Object);
+                VideoWebServiceMock.Object, UserCreationAndNotificationMock.Object, BookingsApiClientMock.Object);
             VideoApiServiceMock.Setup(x => x.BookNewConferenceAsync(It.IsAny<BookNewConferenceRequest>())).ReturnsAsync(new ConferenceDetailsResponse());
 
             var integrationEvent = CreateEvent();
             await messageHandler.HandleAsync(integrationEvent);
             VideoApiServiceMock.Verify(x => x.BookNewConferenceAsync(It.IsAny<BookNewConferenceRequest>()), Times.Once);
+            BookingsApiClientMock.Verify(x => x.UpdateBookingStatusAsync(It.IsAny<Guid>(), It.IsAny<UpdateBookingStatusRequest>()), Times.Once);
         }
 
         [Test]
@@ -45,7 +48,7 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
         {
             var expectedConferenceId = Guid.NewGuid();
             var messageHandler = (IMessageHandler) new HearingReadyForVideoHandler(VideoApiServiceMock.Object,
-                VideoWebServiceMock.Object, UserCreationAndNotificationMock.Object);
+                VideoWebServiceMock.Object, UserCreationAndNotificationMock.Object, BookingsApiClientMock.Object);
             VideoApiServiceMock.Setup(x => x.BookNewConferenceAsync(It.IsAny<BookNewConferenceRequest>())).ReturnsAsync(new ConferenceDetailsResponse { Id = expectedConferenceId});
 
             var integrationEvent = CreateEvent();

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/MessageHandlerTestBase.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/MessageHandlerTestBase.cs
@@ -5,6 +5,7 @@ using BookingQueueSubscriber.Services.NotificationApi;
 using BookingQueueSubscriber.Services.UserApi;
 using BookingQueueSubscriber.Services.VideoApi;
 using BookingQueueSubscriber.Services.VideoWeb;
+using BookingsApi.Client;
 using Moq;
 using NUnit.Framework;
 using VideoApi.Contract.Responses;
@@ -18,6 +19,8 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
         protected Mock<IUserService> UserServiceMock { get; set; }
         protected Mock<INotificationService> NotificationServiceMock { get; set; }
         protected Mock<IUserCreationAndNotification> UserCreationAndNotificationMock { get; set; }
+
+        protected Mock<IBookingsApiClient> BookingsApiClientMock { get; set; }
 
         protected Guid ParticipantId { get; set; }
         protected Guid HearingId { get; set; }
@@ -45,6 +48,7 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
             UserServiceMock = new Mock<IUserService>();
             NotificationServiceMock = new Mock<INotificationService>();
             UserCreationAndNotificationMock = new Mock<IUserCreationAndNotification>();
+            BookingsApiClientMock = new Mock<IBookingsApiClient>();
         }
     }
 }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/UserCreationAndNotificationTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/UserCreationAndNotificationTests.cs
@@ -26,7 +26,6 @@ namespace BookingQueueSubscriber.UnitTests
         private Mock<ILogger<UserCreationAndNotification>> _logger;
         private Mock<ILogger<UserService>> _logger2;
         private Mock<IUserApiClient> _userApi;
-        private Mock<IFeatureToggles> _featureTogglesMock;
         public UserCreationAndNotificationTests()
         {
             _notificationServiceMock = new Mock<INotificationService>();
@@ -35,7 +34,6 @@ namespace BookingQueueSubscriber.UnitTests
             _logger = new Mock<ILogger<UserCreationAndNotification>>();
             _logger2 = new Mock<ILogger<UserService>>();
             _userApi = new Mock<IUserApiClient>();
-            _featureTogglesMock = new Mock<IFeatureToggles>();
         }
 
         [Test]
@@ -98,15 +96,12 @@ namespace BookingQueueSubscriber.UnitTests
                     "", new Dictionary<string, IEnumerable<string>>(), null))
                 .ReturnsAsync(user);
                             
-            _featureTogglesMock.Setup(x => x.SsprToggle()).Returns(false);
-            
-            
             _userApi.Setup(x=>x.CreateUserAsync(It.IsAny<CreateUserRequest>()))
                 .ThrowsAsync(new UserApiException("User already exists",
                     (int) HttpStatusCode.Conflict,
                     "", new Dictionary<string, IEnumerable<string>>(), null));
             
-            var userService = new UserService(_userApi.Object, _logger2.Object, _featureTogglesMock.Object);
+            var userService = new UserService(_userApi.Object, _logger2.Object);
             
             var userCreationAndNotification = new UserCreationAndNotification(_notificationServiceMock.Object,
                 userService, _bookingsAPIMock.Object, _logger.Object);
@@ -138,15 +133,12 @@ namespace BookingQueueSubscriber.UnitTests
                     (int) HttpStatusCode.NotFound,
                     "", new Dictionary<string, IEnumerable<string>>(), null));
                             
-            _featureTogglesMock.Setup(x => x.SsprToggle()).Returns(false);
-            
-            
             _userApi.Setup(x=>x.CreateUserAsync(It.IsAny<CreateUserRequest>()))
                 .ThrowsAsync(new UserApiException("User already exists",
                     (int) HttpStatusCode.Conflict,
                     "", new Dictionary<string, IEnumerable<string>>(), null));
             
-            var userService = new UserService(_userApi.Object, _logger2.Object, _featureTogglesMock.Object);
+            var userService = new UserService(_userApi.Object, _logger2.Object);
             
             var userCreationAndNotification = new UserCreationAndNotification(_notificationServiceMock.Object,
                 userService, _bookingsAPIMock.Object, _logger.Object);
@@ -183,15 +175,12 @@ namespace BookingQueueSubscriber.UnitTests
                     (int) HttpStatusCode.NotFound,
                     "", new Dictionary<string, IEnumerable<string>>(), null));
                             
-            _featureTogglesMock.Setup(x => x.SsprToggle()).Returns(false);
-            
-            
             _userApi.Setup(x=>x.CreateUserAsync(It.IsAny<CreateUserRequest>()))
                 .ThrowsAsync(new UserApiException("User already exists",
                     (int) HttpStatusCode.NotFound,
                     "", new Dictionary<string, IEnumerable<string>>(), null));
             
-            var userService = new UserService(_userApi.Object, _logger2.Object, _featureTogglesMock.Object);
+            var userService = new UserService(_userApi.Object, _logger2.Object);
             
             var userCreationAndNotification = new UserCreationAndNotification(_notificationServiceMock.Object,
                 userService, _bookingsAPIMock.Object, _logger.Object);

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
@@ -134,8 +134,8 @@
       },
       "BookingsApi.Client": {
         "type": "Transitive",
-        "resolved": "1.39.36",
-        "contentHash": "PVgSPCpPs5MTznxJl+vN10vTEMMyO0oWrZW89ghdSj3Ej7ZknwAAcBhQzfwKELF56oERvu+76q1c6I1jnVj3Hg==",
+        "resolved": "1.41.8",
+        "contentHash": "6hxFUsxR6k64cR9iQimTTBd0d7O6J/45mZ+oyxxNfOgn/qqLhcJoI8XZLCYp10yfbOOPYSziJxEZl1xbqjorxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2349,46 +2349,46 @@
       "bookingqueuesubscriber": {
         "type": "Project",
         "dependencies": {
-          "BookingQueueSubscriber.Services": "[1.0.0, )",
-          "BookingsApi.Client": "[1.39.36, )",
-          "Microsoft.ApplicationInsights.AspNetCore": "[2.21.0, )",
-          "Microsoft.AspNetCore.Hosting": "[2.2.7, )",
-          "Microsoft.Azure.WebJobs": "[3.0.33, )",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "[5.8.0, )",
-          "Microsoft.Extensions.Configuration.Abstractions": "[6.0.0, )",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[6.0.1, )",
-          "Microsoft.Extensions.DependencyInjection": "[6.0.1, )",
-          "Microsoft.Extensions.Http": "[6.0.0, )",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
-          "Microsoft.NET.Sdk.Functions": "[4.1.3, )",
-          "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
-          "System.Threading.Tasks.Extensions": "[4.5.4, )"
+          "BookingQueueSubscriber.Services": "1.0.0",
+          "BookingsApi.Client": "1.41.8",
+          "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
+          "Microsoft.AspNetCore.Hosting": "2.2.7",
+          "Microsoft.Azure.WebJobs": "3.0.33",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.8.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "6.0.1",
+          "Microsoft.Extensions.DependencyInjection": "6.0.1",
+          "Microsoft.Extensions.Http": "6.0.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
+          "Microsoft.NET.Sdk.Functions": "4.1.3",
+          "System.IdentityModel.Tokens.Jwt": "6.25.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[6.3.3, )",
-          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
-          "Newtonsoft.Json": "[13.0.1, )",
-          "VH.Core.Configuration": "[0.1.12, )"
+          "LaunchDarkly.ServerSdk": "6.3.3",
+          "Microsoft.Azure.Functions.Extensions": "1.1.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
+          "Microsoft.Extensions.Configuration.Json": "6.0.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
+          "Newtonsoft.Json": "13.0.1",
+          "VH.Core.Configuration": "0.1.12"
         }
       },
       "bookingqueuesubscriber.services": {
         "type": "Project",
         "dependencies": {
-          "BookingQueueSubscriber.Common": "[1.0.0, )",
-          "BookingsApi.Client": "[1.39.36, )",
-          "LaunchDarkly.ServerSdk": "[6.3.3, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[6.0.2, )",
-          "NotificationApi.Client": "[1.38.11, )",
-          "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
-          "TimeZoneConverter": "[3.3.0, )",
-          "UserApi.Client": "[1.40.1, )",
-          "VideoApi.Client": "[1.41.5, )"
+          "BookingQueueSubscriber.Common": "1.0.0",
+          "BookingsApi.Client": "1.41.8",
+          "LaunchDarkly.ServerSdk": "6.3.3",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.2",
+          "NotificationApi.Client": "1.38.11",
+          "System.IdentityModel.Tokens.Jwt": "6.25.0",
+          "TimeZoneConverter": "3.3.0",
+          "UserApi.Client": "1.40.1",
+          "VideoApi.Client": "1.41.5"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber/BookingQueueSubscriber.csproj
+++ b/BookingQueueSubscriber/BookingQueueSubscriber/BookingQueueSubscriber.csproj
@@ -11,7 +11,7 @@
     <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BookingsApi.Client" Version="1.39.36" />
+    <PackageReference Include="BookingsApi.Client" Version="1.41.8" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />

--- a/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "BookingsApi.Client": {
         "type": "Direct",
-        "requested": "[1.39.36, )",
-        "resolved": "1.39.36",
-        "contentHash": "PVgSPCpPs5MTznxJl+vN10vTEMMyO0oWrZW89ghdSj3Ej7ZknwAAcBhQzfwKELF56oERvu+76q1c6I1jnVj3Hg==",
+        "requested": "[1.41.8, )",
+        "resolved": "1.41.8",
+        "contentHash": "6hxFUsxR6k64cR9iQimTTBd0d7O6J/45mZ+oyxxNfOgn/qqLhcJoI8XZLCYp10yfbOOPYSziJxEZl1xbqjorxw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2261,27 +2261,27 @@
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[6.3.3, )",
-          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
-          "Newtonsoft.Json": "[13.0.1, )",
-          "VH.Core.Configuration": "[0.1.12, )"
+          "LaunchDarkly.ServerSdk": "6.3.3",
+          "Microsoft.Azure.Functions.Extensions": "1.1.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
+          "Microsoft.Extensions.Configuration.Json": "6.0.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
+          "Newtonsoft.Json": "13.0.1",
+          "VH.Core.Configuration": "0.1.12"
         }
       },
       "bookingqueuesubscriber.services": {
         "type": "Project",
         "dependencies": {
-          "BookingQueueSubscriber.Common": "[1.0.0, )",
-          "BookingsApi.Client": "[1.39.36, )",
-          "LaunchDarkly.ServerSdk": "[6.3.3, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[6.0.2, )",
-          "NotificationApi.Client": "[1.38.11, )",
-          "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
-          "TimeZoneConverter": "[3.3.0, )",
-          "UserApi.Client": "[1.40.1, )",
-          "VideoApi.Client": "[1.41.5, )"
+          "BookingQueueSubscriber.Common": "1.0.0",
+          "BookingsApi.Client": "1.41.8",
+          "LaunchDarkly.ServerSdk": "6.3.3",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.2",
+          "NotificationApi.Client": "1.38.11",
+          "System.IdentityModel.Tokens.Jwt": "6.25.0",
+          "TimeZoneConverter": "3.3.0",
+          "UserApi.Client": "1.40.1",
+          "VideoApi.Client": "1.41.5"
         }
       }
     }


### PR DESCRIPTION
Removed SSPR group assignment as it is applied globally to all users in AAD. Added a call to the update booking status after the conference is created

**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
