### PR TITLE
VIH-9527 - Video Web Last minute booking representatives unable to call endpoint for private consultation

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
@@ -59,11 +59,14 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
                 }
             }
 
-            await _videoApiService.UpdateEndpointInConference(conference.Id, eventMessage.Sip, new UpdateEndpointRequest
+            if (conference != null)
             {
-                DisplayName = eventMessage.DisplayName,
-                DefenceAdvocate = defenceAdvocate?.Username
-            });
+                await _videoApiService.UpdateEndpointInConference(conference.Id, eventMessage.Sip, new UpdateEndpointRequest
+                {
+                    DisplayName = eventMessage.DisplayName,
+                    DefenceAdvocate = defenceAdvocate?.Username
+                });
+            }
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
@@ -1,8 +1,10 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using BookingQueueSubscriber.Services.IntegrationEvents;
 using BookingQueueSubscriber.Services.MessageHandlers.Core;
 using BookingQueueSubscriber.Services.VideoApi;
+using Microsoft.Extensions.Logging;
 using VideoApi.Contract.Requests;
 using VideoApi.Contract.Responses;
 
@@ -11,26 +13,57 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
     public class EndpointUpdatedHandler : IMessageHandler<EndpointUpdatedIntegrationEvent>
     {
         private readonly IVideoApiService _videoApiService;
+        private readonly ILogger<EndpointUpdatedHandler> _logger;
+        private const int RetryLimit = 3;
+        private const int RetrySleep = 3000;
 
-        public EndpointUpdatedHandler(IVideoApiService videoApiService)
+        public EndpointUpdatedHandler(IVideoApiService videoApiService, ILogger<EndpointUpdatedHandler> logger)
         {
             _videoApiService = videoApiService;
+            _logger = logger;
         }
 
         public async Task HandleAsync(EndpointUpdatedIntegrationEvent eventMessage)
         {
-            var conference = await _videoApiService.GetConferenceByHearingRefId(eventMessage.HearingId);
             ParticipantDetailsResponse defenceAdvocate = null;
+            ConferenceDetailsResponse conference = null;
+
             if (!string.IsNullOrEmpty(eventMessage.DefenceAdvocate))
             {
-                defenceAdvocate = conference.Participants.Single(x => x.ContactEmail ==
-                    eventMessage.DefenceAdvocate);
+                for (var retry = 0; retry <= RetryLimit; retry++)
+                {
+                    conference = await _videoApiService.GetConferenceByHearingRefId(eventMessage.HearingId);
+
+                    defenceAdvocate = conference.Participants.SingleOrDefault(x => x.ContactEmail ==
+                                eventMessage.DefenceAdvocate);
+
+                    if (defenceAdvocate != null)
+                    {
+                        break;
+                    }
+
+                    if (retry == RetryLimit)
+                    {
+                        _logger.LogError("Unable to find defence advocate email by hearing id {HearingId}", eventMessage.HearingId);
+                        break;
+                    }
+
+                    Thread.Sleep(RetrySleep);
+                }
             }
-            await _videoApiService.UpdateEndpointInConference(conference.Id, eventMessage.Sip, new UpdateEndpointRequest
+
+            if (conference != null)
             {
-                DisplayName = eventMessage.DisplayName,
-                DefenceAdvocate = defenceAdvocate?.Username
-            });
+                await _videoApiService.UpdateEndpointInConference(conference.Id, eventMessage.Sip, new UpdateEndpointRequest
+                {
+                    DisplayName = eventMessage.DisplayName,
+                    DefenceAdvocate = defenceAdvocate?.Username
+                });
+            }
+            else
+            {
+                _logger.LogError("Unable to find conference by hearing id {HearingId}", eventMessage.HearingId);
+            }
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
@@ -25,7 +25,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
 
         public async Task HandleAsync(EndpointUpdatedIntegrationEvent eventMessage)
         {
-            ConferenceDetailsResponse conference = await _videoApiService.GetConferenceByHearingRefId(eventMessage.HearingId);
+            var conference = await _videoApiService.GetConferenceByHearingRefId(eventMessage.HearingId);
             ParticipantDetailsResponse defenceAdvocate = null;
             
             if (!string.IsNullOrEmpty(eventMessage.DefenceAdvocate))

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/EndpointUpdatedHandler.cs
@@ -30,7 +30,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             
             if (!string.IsNullOrEmpty(eventMessage.DefenceAdvocate))
             {
-                defenceAdvocate = await this.GetDefenceAdvocate(conference, eventMessage);
+                defenceAdvocate = await GetDefenceAdvocate(conference, eventMessage);
             }
 
             if (conference != null)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/EndpointDefenceAdvocateHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/EndpointDefenceAdvocateHandlerTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Threading.Tasks;
+using BookingQueueSubscriber.Services.IntegrationEvents;
+using BookingQueueSubscriber.Services.MessageHandlers;
+using BookingQueueSubscriber.Services.MessageHandlers.Core;
+using VideoApi.Contract.Requests;
+using Moq;
+using NUnit.Framework;
+using Microsoft.Extensions.Logging;
+using VideoApi.Contract.Responses;
+
+namespace BookingQueueSubscriber.UnitTests.MessageHandlers
+{
+    public class EndpointDefenceAdvocateHandlerTests : MessageHandlerTestBase
+    {
+        protected Mock<ILogger<EndpointUpdatedHandler>> logger;
+
+        [Test]
+        public async Task should_log_error_when_conference_is_null()
+        {
+            ConferenceDetailsResponse conference = null; 
+            VideoApiServiceMock.Setup(x => x.GetConferenceByHearingRefId(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(conference);
+
+            logger = new Mock<ILogger<EndpointUpdatedHandler>>();
+            var messageHandler = new EndpointUpdatedHandler(VideoApiServiceMock.Object, logger.Object);
+
+            var integrationEvent = GetIntegrationEventValid();
+            await messageHandler.HandleAsync(integrationEvent);
+
+            logger.Verify(x => x.Log(
+                It.Is<LogLevel>(log => log == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString().Contains("Unable to find conference by hearing id")),
+                It.Is<Exception>(x => x == null),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Exactly(4));
+
+            VideoApiServiceMock.Verify(x => x.UpdateEndpointInConference(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<UpdateEndpointRequest>()), Times.Never);
+        }
+
+        [Test]
+        public async Task should_log_error_when_retry_limit_is_reached()
+        {
+            logger = new Mock<ILogger<EndpointUpdatedHandler>>();
+            var messageHandler = new EndpointUpdatedHandler(VideoApiServiceMock.Object, logger.Object);
+
+            var integrationEvent = GetIntegrationEventInvalid();
+            await messageHandler.HandleAsync(integrationEvent);
+
+            logger.Verify(x => x.Log(
+                It.Is<LogLevel>(log => log == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString().Contains("Unable to find defence advocate email by hearing id")),
+                It.Is<Exception>(x => x == null),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+
+            VideoApiServiceMock.Verify(x => x.UpdateEndpointInConference(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<UpdateEndpointRequest>()), Times.Once);
+        }
+
+        [Test]
+        public async Task should_not_log_error_when_defence_advocate_is_found()
+        {
+            logger = new Mock<ILogger<EndpointUpdatedHandler>>();
+            var messageHandler = new EndpointUpdatedHandler(VideoApiServiceMock.Object, logger.Object);
+
+            var integrationEvent = GetIntegrationEventValid();
+            await messageHandler.HandleAsync(integrationEvent);
+
+            logger.Verify(x => x.Log(
+                It.Is<LogLevel>(log => log == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString().Contains("Unable to find defence advocate email by hearing id")),
+                It.Is<Exception>(x => x == null),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Never);
+
+            VideoApiServiceMock.Verify(x => x.UpdateEndpointInConference(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<UpdateEndpointRequest>()), Times.Once);
+        }
+
+        private EndpointUpdatedIntegrationEvent GetIntegrationEventValid()
+        {
+            return new EndpointUpdatedIntegrationEvent
+            {
+                HearingId = HearingId,
+                Sip = Guid.NewGuid().ToString(),
+                DisplayName = "two",
+                DefenceAdvocate = "test@hmcts.net"
+            };
+        }
+
+        private EndpointUpdatedIntegrationEvent GetIntegrationEventInvalid()
+        {
+            return new EndpointUpdatedIntegrationEvent
+            {
+                HearingId = HearingId,
+                Sip = Guid.NewGuid().ToString(),
+                DisplayName = "two",
+                DefenceAdvocate = "test1@hmcts.net"
+            };
+        }
+    }
+}

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/EndpointDefenceAdvocateHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/EndpointDefenceAdvocateHandlerTests.cs
@@ -32,7 +32,7 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((@object, @type) => @object.ToString().Contains("Unable to find conference by hearing id")),
                 It.Is<Exception>(x => x == null),
-                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Exactly(4));
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
 
             VideoApiServiceMock.Verify(x => x.UpdateEndpointInConference(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<UpdateEndpointRequest>()), Times.Never);
         }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/EndpointUpdatedHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/EndpointUpdatedHandlerTests.cs
@@ -6,15 +6,19 @@ using BookingQueueSubscriber.Services.MessageHandlers.Core;
 using VideoApi.Contract.Requests;
 using Moq;
 using NUnit.Framework;
+using Microsoft.Extensions.Logging;
 
 namespace BookingQueueSubscriber.UnitTests.MessageHandlers
 {
     public class EndpointUpdatedHandlerTests : MessageHandlerTestBase
     {
+        protected Mock<ILogger<EndpointUpdatedHandler>> logger;
+
         [Test]
         public async Task should_call_video_api_when_request_is_valid()
         {
-            var messageHandler = new EndpointUpdatedHandler(VideoApiServiceMock.Object);
+            logger = new Mock<ILogger<EndpointUpdatedHandler>>();
+            var messageHandler = new EndpointUpdatedHandler(VideoApiServiceMock.Object, logger.Object);
 
             var integrationEvent = GetIntegrationEvent();
             await messageHandler.HandleAsync(integrationEvent);
@@ -24,7 +28,8 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
         [Test]
         public async Task should_call_video_api_when_handle_is_called_with_explicit_interface()
         {
-            var messageHandler = (IMessageHandler) new EndpointUpdatedHandler(VideoApiServiceMock.Object);
+            logger = new Mock<ILogger<EndpointUpdatedHandler>>();
+            var messageHandler = (IMessageHandler) new EndpointUpdatedHandler(VideoApiServiceMock.Object, logger.Object);
 
             var integrationEvent = GetIntegrationEvent();
             await messageHandler.HandleAsync(integrationEvent);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/VIH-9527

1. Added for loop with a retry limit to get the conference details which includes the list of conference participants
2. Added if else statement to log error if conference returns null, and proceed to get the defence advocate should conference return a value
3. Attempting to pull defence advocate from the list of participants with matching contact email to the defence advocate sent in event message
4. Added logging if retry limit is reached before defence advocate email is found
5. Added thread sleeping between each retry. Determined by the RetrySleep value
6. Added logging if conference pulled down for this is null