### PR TITLE
VIH-10227 Fix - Edit Hearing - new participants cannot log into Video Web

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/HearingParticipantsUpdatedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/HearingParticipantsUpdatedHandler.cs
@@ -42,10 +42,10 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
                     LinkedParticipants = eventMessage.LinkedParticipants.Select(LinkedParticipantToRequestMapper.MapToLinkedParticipantRequest).ToList(),
                 };
                 await _videoApiService.UpdateConferenceParticipantsAsync(conferenceResponse.Id, updateConferenceParticipantsRequest);
+       
+                await _userCreationAndNotification.HandleAssignUserToGroup(newParticipantUsers);
                 
                 await _videoWebService.PushParticipantsUpdatedMessage(conferenceResponse.Id, updateConferenceParticipantsRequest);
-                
-                await _userCreationAndNotification.HandleAssignUserToGroup(newParticipantUsers);
                 
             }
             catch (Exception e)

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -2,14 +2,12 @@
 java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
-  environment:
-    QUEUENAME: oliver-booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: oliver-booking
+    queueName: booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -2,12 +2,14 @@
 java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
+  environment:
+    QUEUENAME: oliver-booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: booking
+    queueName: oliver-booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10227


### Change description ###
Fixes an issue where if you edit a hearing and then add new participants, those participants are not added to any AAD groups and cannot log into Video Web.

This issue is specific to the Dev environment and is a side effect of the VPN issue. It messages Video Web and then assigns the participants to AAD groups, however on the Dev environment Video Web is unreachable as it outside VPN, so it throws an exception before it has assigned to AAD groups.

Fix by swapping these lines round - ie assign to groups before messaging Video Web. This also matches the order these events are done in `HearingReadyForVideoHandler`.