### PR TITLE
VIH-10352 Add users to AAD groups before sending notifications

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
@@ -28,6 +28,9 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
 
             message.Username = newUser.UserName;
 
+            await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
+            await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
+            
             await _notificationApiClient.SendParticipantCreatedAccountEmailAsync(new SignInDetailsEmailRequest
             {
                 ContactEmail = message.ContactEmail,
@@ -36,9 +39,6 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
                 Username = message.Username,
                 Password = newUser.Password,
             });
-
-            await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
-            await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
@@ -46,8 +46,8 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
 
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
 
-            await _notificationApiClient.SendParticipantSingleDayHearingConfirmationForNewUserEmailAsync(request);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
+            await _notificationApiClient.SendParticipantSingleDayHearingConfirmationForNewUserEmailAsync(request);
         }
         async Task IMessageHandler.HandleAsync(object integrationEvent)
         {

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantMultidayHearingConfirmationHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantMultidayHearingConfirmationHandler.cs
@@ -45,8 +45,8 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             };
 
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
-            await _notificationApiClient.SendParticipantMultiDayHearingConfirmationForNewUserEmailAsync(request);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
+            await _notificationApiClient.SendParticipantMultiDayHearingConfirmationForNewUserEmailAsync(request);
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -3,15 +3,13 @@ java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-781.dev.platform.hmcts.net/
-    VHSERVICES__NOTIFICATIONAPIURL : https://vh-notification-api-pr-148.dev.platform.hmcts.net/
-    QUEUENAME: oliver-booking
+    QUEUENAME: booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: oliver-booking
+    queueName: booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -4,6 +4,7 @@ java:
   releaseNameOverride: ${RELEASE_NAME}
   environment:
     VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-781.dev.platform.hmcts.net/
+    VHSERVICES__NOTIFICATIONAPIURL : https://vh-notification-api-pr-148.dev.platform.hmcts.net/
     QUEUENAME: oliver-booking
 function:
   releaseNameOverride: ${RELEASE_NAME}

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -3,13 +3,14 @@ java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    QUEUENAME: booking
+    VHSERVICES__BOOKINGSAPIURL: https://vh-bookings-api-pr-781.dev.platform.hmcts.net/
+    QUEUENAME: oliver-booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: booking
+    queueName: oliver-booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10352


### Change description ###
Add users to groups before sending the notifications, to ensure that users are still added to the AAD groups in the event of a notification failure.

Not required to fix the original issue, but makes the handling more robust.