### PR TITLE
VIH-10390 Fix for error starting hearing with new linked participant users

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
@@ -23,7 +23,7 @@
       </PackageReference>
       <PackageReference Include="TimeZoneConverter" Version="3.3.0" />
       <PackageReference Include="UserApi.Client" Version="1.45.2" />
-      <PackageReference Include="VideoApi.Client" Version="1.50.1-pr-0627-0002" />
+      <PackageReference Include="VideoApi.Client" Version="1.50.1" />
       <PackageReference Include="NotificationApi.Client" Version="1.49.2" />
 
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.0" />

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/BookingQueueSubscriber.Services.csproj
@@ -23,7 +23,7 @@
       </PackageReference>
       <PackageReference Include="TimeZoneConverter" Version="3.3.0" />
       <PackageReference Include="UserApi.Client" Version="1.45.2" />
-      <PackageReference Include="VideoApi.Client" Version="1.48.6" />
+      <PackageReference Include="VideoApi.Client" Version="1.50.1-pr-0627-0002" />
       <PackageReference Include="NotificationApi.Client" Version="1.49.2" />
 
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.0" />

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
@@ -44,7 +44,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
                 Password = newUser.Password,
             });
 
-            await _videoApiService.UpdateParticipantDetailsWithPolling(message.HearingId, newUser.UserName, message);
+            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
@@ -34,7 +34,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
-            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
+            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ContactEmail);
             await _notificationApiClient.SendParticipantCreatedAccountEmailAsync(new SignInDetailsEmailRequest
             {
                 ContactEmail = message.ContactEmail,

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/CreateAndNotifyUserHandler.cs
@@ -34,7 +34,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
-            
+            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
             await _notificationApiClient.SendParticipantCreatedAccountEmailAsync(new SignInDetailsEmailRequest
             {
                 ContactEmail = message.ContactEmail,
@@ -43,8 +43,6 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
                 Username = message.Username,
                 Password = newUser.Password,
             });
-
-            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
@@ -48,7 +48,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
-            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
+            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ContactEmail);
             await _notificationApiClient.SendParticipantSingleDayHearingConfirmationForNewUserEmailAsync(request);
         }
 

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
@@ -49,7 +49,7 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
             await _notificationApiClient.SendParticipantSingleDayHearingConfirmationForNewUserEmailAsync(request);
-            await _videoApiService.UpdateParticipantDetailsWithPolling(message.HearingId, newUser.UserName, message);
+            await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/NewParticipantHearingConfirmationHandler.cs
@@ -48,8 +48,8 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
             
             await _bookingsApiClient.UpdatePersonUsernameAsync(message.ContactEmail, message.Username);
             await _userService.AssignUserToGroup(newUser.UserId, message.UserRole);
-            await _notificationApiClient.SendParticipantSingleDayHearingConfirmationForNewUserEmailAsync(request);
             await _videoApiService.UpdateParticipantUsernameWithPolling(message.HearingId, newUser.UserName, message.ParticipantId);
+            await _notificationApiClient.SendParticipantSingleDayHearingConfirmationForNewUserEmailAsync(request);
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/IVideoApiService.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/IVideoApiService.cs
@@ -18,6 +18,6 @@ namespace BookingQueueSubscriber.Services.VideoApi
         Task RemoveEndpointFromConference(Guid conferenceId, string sip);
         Task UpdateEndpointInConference(Guid conferenceId, string sip, UpdateEndpointRequest request);
         Task CloseConsultation(Guid conferenceId, Guid participantId);
-        Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, Guid participantId);
+        Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, string contactEmail);
     }
 }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/IVideoApiService.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/IVideoApiService.cs
@@ -18,6 +18,6 @@ namespace BookingQueueSubscriber.Services.VideoApi
         Task RemoveEndpointFromConference(Guid conferenceId, string sip);
         Task UpdateEndpointInConference(Guid conferenceId, string sip, UpdateEndpointRequest request);
         Task CloseConsultation(Guid conferenceId, Guid participantId);
-        Task UpdateParticipantDetailsWithPolling(Guid hearingId, string username, HearingConfirmationForParticipantDto message);
+        Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, Guid participantId);
     }
 }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiService.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiService.cs
@@ -103,7 +103,7 @@ namespace BookingQueueSubscriber.Services.VideoApi
             return _apiClient.UpdateParticipantUsernameAsync(participantId, new UpdateParticipantUsernameRequest { Username = username });
         }
 
-        public async Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, Guid participantId)
+        public async Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, string contactEmail)
         {
             var pollCount = 0;
             
@@ -113,7 +113,8 @@ namespace BookingQueueSubscriber.Services.VideoApi
                 pollCount++;
             } while (conferenceResponse == null);
 
-            await UpdateParticipantUsername(participantId, username);
+            var participant = conferenceResponse.Participants.Single(x => x.ContactEmail == contactEmail);
+            await UpdateParticipantUsername(participant.Id, username);
             
             async Task<ConferenceDetailsResponse> PollForConferenceDetails()
             {

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiService.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiService.cs
@@ -97,7 +97,13 @@ namespace BookingQueueSubscriber.Services.VideoApi
             return _apiClient.LeaveConsultationAsync(new LeaveConsultationRequest{ConferenceId = conferenceId, ParticipantId = participantId});
         }
 
-        public async Task UpdateParticipantDetailsWithPolling(Guid hearingId, string username, HearingConfirmationForParticipantDto message)
+        private Task UpdateParticipantUsername(Guid participantId, string username)
+        {
+            _logger.LogInformation("Updating username for participant {participantId}", participantId);
+            return _apiClient.UpdateParticipantUsernameAsync(participantId, new UpdateParticipantUsernameRequest { Username = username });
+        }
+
+        public async Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, Guid participantId)
         {
             var pollCount = 0;
             
@@ -106,21 +112,8 @@ namespace BookingQueueSubscriber.Services.VideoApi
                 conferenceResponse = await PollForConferenceDetails(); 
                 pollCount++;
             } while (conferenceResponse == null);
-            
-            var participant = conferenceResponse.Participants.Single(x => x.ContactEmail == message.ContactEmail);
-            var updateParticipantDetailsRequest = new UpdateParticipantRequest
-            {
-                ParticipantRefId = participant.RefId,
-                FirstName = message.FirstName,
-                LastName = message.LastName,
-                Fullname = $"{message.FirstName} {message.LastName}",
-                DisplayName = message.DisplayName,
-                Representee = message.Representee,
-                ContactEmail = message.ContactEmail,
-                ContactTelephone = message.ContactTelephone,
-                Username = username
-            };
-            await UpdateParticipantDetails(conferenceResponse.Id, participant.Id, updateParticipantDetailsRequest);
+
+            await UpdateParticipantUsername(participantId, username);
             
             async Task<ConferenceDetailsResponse> PollForConferenceDetails()
             {

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiServiceFake.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiServiceFake.cs
@@ -139,7 +139,7 @@ namespace BookingQueueSubscriber.Services.VideoApi
             return Task.FromResult(HttpStatusCode.OK);
         }
 
-        public Task UpdateParticipantDetailsWithPolling(Guid hearingId, string username, HearingConfirmationForParticipantDto message)
+        public Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, Guid participantId)
         {
             UpdateParticipantDetailsCount++;
             return Task.FromResult(HttpStatusCode.OK);

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiServiceFake.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/VideoApi/VideoApiServiceFake.cs
@@ -139,7 +139,7 @@ namespace BookingQueueSubscriber.Services.VideoApi
             return Task.FromResult(HttpStatusCode.OK);
         }
 
-        public Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, Guid participantId)
+        public Task UpdateParticipantUsernameWithPolling(Guid hearingId, string username, string contactEmail)
         {
             UpdateParticipantDetailsCount++;
             return Task.FromResult(HttpStatusCode.OK);

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
@@ -74,9 +74,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.48.6, )",
-        "resolved": "1.48.6",
-        "contentHash": "Q0ULqmgAbKWqlV1/Vv/NikKXGQMTLyvJxx5dm+VPBMtS9Fokt2rtDlBiAJDLX7A81UxXj/SU0evQ43IoiU8oUw==",
+        "requested": "[1.50.1-pr-0627-0002, )",
+        "resolved": "1.50.1-pr-0627-0002",
+        "contentHash": "DvfZPCdbnVAaAkx9Pn2oYcxI6kl4shLeq7j/k/642N5XSO4/l5yiWluN9lHlmkizCpQSiCSnXiDkoVDzkHI87Q==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -1762,15 +1762,15 @@
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "1.46.10",
-          "LaunchDarkly.ServerSdk": "7.0.3",
-          "Microsoft.ApplicationInsights": "2.21.0",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
-          "Newtonsoft.Json": "13.0.1",
-          "VH.Core.Configuration": "0.1.13"
+          "BookingsApi.Client": "[1.46.10, )",
+          "LaunchDarkly.ServerSdk": "[7.0.3, )",
+          "Microsoft.ApplicationInsights": "[2.21.0, )",
+          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
+          "Newtonsoft.Json": "[13.0.1, )",
+          "VH.Core.Configuration": "[0.1.13, )"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/packages.lock.json
@@ -74,9 +74,9 @@
       },
       "VideoApi.Client": {
         "type": "Direct",
-        "requested": "[1.50.1-pr-0627-0002, )",
-        "resolved": "1.50.1-pr-0627-0002",
-        "contentHash": "DvfZPCdbnVAaAkx9Pn2oYcxI6kl4shLeq7j/k/642N5XSO4/l5yiWluN9lHlmkizCpQSiCSnXiDkoVDzkHI87Q==",
+        "requested": "[1.50.1, )",
+        "resolved": "1.50.1",
+        "contentHash": "OJqOqsRFAdxGyHVfrj6zo7GdGl/aVXAoLl0EpiWnwbU+2wAIwzicI8u5TwxahmeG8Gjtji7SHx3x/A4n0WWOPQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/VideoApiServiceTests/UpdateParticipantUsernameWithPollingTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/VideoApiServiceTests/UpdateParticipantUsernameWithPollingTests.cs
@@ -1,15 +1,13 @@
 using System.Net;
-using BookingQueueSubscriber.Services.MessageHandlers.Dtos;
 using BookingQueueSubscriber.Services.UserApi;
 using BookingQueueSubscriber.Services.VideoApi;
-using BookingsApi.Client;
 using Microsoft.Extensions.Logging;
-using NotificationApi.Client;
 using VideoApi.Client;
 using VideoApi.Contract.Responses;
+
 namespace BookingQueueSubscriber.UnitTests.VideoApiServiceTests
 {
-    public class UpdateParticipantDetailsWithPollingTests
+    public class UpdateParticipantUsernameWithPollingTests
     {
         private Mock<IUserService> _userServiceMock;
         private Mock<IVideoApiClient> _videoApiClientMock;
@@ -39,21 +37,8 @@ namespace BookingQueueSubscriber.UnitTests.VideoApiServiceTests
             _videoApiClientMock.Setup(x => x.GetConferenceByHearingRefIdAsync(It.IsAny<Guid>(), It.IsAny<bool>()))
                 .ThrowsAsync(new VideoApiException("Conference not found", (int)HttpStatusCode.NotFound, "Conference not found", null, null));
             
-            var message = new HearingConfirmationForParticipantDto
-            {
-                HearingId = _hearingId,
-                ParticipantId = _participantId,
-                ContactEmail = "email@email.com",
-                FirstName = "John",
-                LastName = "Smith",
-                UserRole = "Individual",
-                CaseName = "Case Name",
-                CaseNumber = "1234567890",
-                ScheduledDateTime = DateTime.UtcNow
-            };
-            
             //assert that message handler throws exception
-            Assert.ThrowsAsync<VideoApiException>(() => _videoApiService.UpdateParticipantDetailsWithPolling(_hearingId, "username", message));
+            Assert.ThrowsAsync<VideoApiException>(() => _videoApiService.UpdateParticipantUsernameWithPolling(_hearingId, "username", _participantId));
         }
     
         [Test]
@@ -76,21 +61,8 @@ namespace BookingQueueSubscriber.UnitTests.VideoApiServiceTests
                         }
                     }
                 });
-                
-            
-            var message = new HearingConfirmationForParticipantDto
-            {
-                HearingId = _hearingId,
-                ParticipantId = _participantId,
-                ContactEmail = "email@email.com",
-                FirstName = "John",
-                LastName = "Smith",
-                UserRole = "Individual",
-                CaseName = "Case Name",
-                CaseNumber = "1234567890",
-                ScheduledDateTime = DateTime.UtcNow
-            };
-            await _videoApiService.UpdateParticipantDetailsWithPolling(_hearingId, "username", message);
+
+            await _videoApiService.UpdateParticipantUsernameWithPolling(_hearingId, "username", _participantId);
             //assert service does not throw exception
             Assert.Pass();
         }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/VideoApiServiceTests/UpdateParticipantUsernameWithPollingTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/VideoApiServiceTests/UpdateParticipantUsernameWithPollingTests.cs
@@ -38,7 +38,7 @@ namespace BookingQueueSubscriber.UnitTests.VideoApiServiceTests
                 .ThrowsAsync(new VideoApiException("Conference not found", (int)HttpStatusCode.NotFound, "Conference not found", null, null));
             
             //assert that message handler throws exception
-            Assert.ThrowsAsync<VideoApiException>(() => _videoApiService.UpdateParticipantUsernameWithPolling(_hearingId, "username", _participantId));
+            Assert.ThrowsAsync<VideoApiException>(() => _videoApiService.UpdateParticipantUsernameWithPolling(_hearingId, "username", "email@email.com"));
         }
     
         [Test]
@@ -62,7 +62,7 @@ namespace BookingQueueSubscriber.UnitTests.VideoApiServiceTests
                     }
                 });
 
-            await _videoApiService.UpdateParticipantUsernameWithPolling(_hearingId, "username", _participantId);
+            await _videoApiService.UpdateParticipantUsernameWithPolling(_hearingId, "username", "email@email.com");
             //assert service does not throw exception
             Assert.Pass();
         }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
@@ -2246,8 +2246,8 @@
       },
       "VideoApi.Client": {
         "type": "Transitive",
-        "resolved": "1.50.1-pr-0627-0002",
-        "contentHash": "DvfZPCdbnVAaAkx9Pn2oYcxI6kl4shLeq7j/k/642N5XSO4/l5yiWluN9lHlmkizCpQSiCSnXiDkoVDzkHI87Q==",
+        "resolved": "1.50.1",
+        "contentHash": "OJqOqsRFAdxGyHVfrj6zo7GdGl/aVXAoLl0EpiWnwbU+2wAIwzicI8u5TwxahmeG8Gjtji7SHx3x/A4n0WWOPQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2308,7 +2308,7 @@
           "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
           "TimeZoneConverter": "[3.3.0, )",
           "UserApi.Client": "[1.45.2, )",
-          "VideoApi.Client": "[1.50.1-pr-0627-0002, )"
+          "VideoApi.Client": "[1.50.1, )"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/packages.lock.json
@@ -2246,8 +2246,8 @@
       },
       "VideoApi.Client": {
         "type": "Transitive",
-        "resolved": "1.48.6",
-        "contentHash": "Q0ULqmgAbKWqlV1/Vv/NikKXGQMTLyvJxx5dm+VPBMtS9Fokt2rtDlBiAJDLX7A81UxXj/SU0evQ43IoiU8oUw==",
+        "resolved": "1.50.1-pr-0627-0002",
+        "contentHash": "DvfZPCdbnVAaAkx9Pn2oYcxI6kl4shLeq7j/k/642N5XSO4/l5yiWluN9lHlmkizCpQSiCSnXiDkoVDzkHI87Q==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2264,51 +2264,51 @@
       "bookingqueuesubscriber": {
         "type": "Project",
         "dependencies": {
-          "AspNetCore.HealthChecks.Uris": "6.0.3",
-          "BookingQueueSubscriber.Services": "1.0.0",
-          "BookingsApi.Client": "1.46.10",
-          "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
-          "Microsoft.AspNetCore.Hosting": "2.2.7",
-          "Microsoft.Azure.WebJobs": "3.0.33",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.8.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Configuration.UserSecrets": "6.0.1",
-          "Microsoft.Extensions.DependencyInjection": "6.0.1",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
-          "Microsoft.NET.Sdk.Functions": "4.1.3",
-          "NotificationApi.Client": "1.49.2",
-          "Rixian.Extensions.ApplicationInsights.WorkerService": "2.1.19",
-          "System.IdentityModel.Tokens.Jwt": "6.25.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "AspNetCore.HealthChecks.Uris": "[6.0.3, )",
+          "BookingQueueSubscriber.Services": "[1.0.0, )",
+          "BookingsApi.Client": "[1.46.10, )",
+          "Microsoft.ApplicationInsights.AspNetCore": "[2.21.0, )",
+          "Microsoft.AspNetCore.Hosting": "[2.2.7, )",
+          "Microsoft.Azure.WebJobs": "[3.0.33, )",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "[5.8.0, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[6.0.0, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[6.0.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[6.0.1, )",
+          "Microsoft.Extensions.Http": "[6.0.0, )",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
+          "Microsoft.NET.Sdk.Functions": "[4.1.3, )",
+          "NotificationApi.Client": "[1.49.2, )",
+          "Rixian.Extensions.ApplicationInsights.WorkerService": "[2.1.19, )",
+          "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
+          "System.Threading.Tasks.Extensions": "[4.5.4, )"
         }
       },
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "1.46.10",
-          "LaunchDarkly.ServerSdk": "7.0.3",
-          "Microsoft.ApplicationInsights": "2.21.0",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
-          "Newtonsoft.Json": "13.0.1",
-          "VH.Core.Configuration": "0.1.13"
+          "BookingsApi.Client": "[1.46.10, )",
+          "LaunchDarkly.ServerSdk": "[7.0.3, )",
+          "Microsoft.ApplicationInsights": "[2.21.0, )",
+          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
+          "Newtonsoft.Json": "[13.0.1, )",
+          "VH.Core.Configuration": "[0.1.13, )"
         }
       },
       "bookingqueuesubscriber.services": {
         "type": "Project",
         "dependencies": {
-          "BookingQueueSubscriber.Common": "1.0.0",
-          "BookingsApi.Client": "1.46.10",
-          "LaunchDarkly.ServerSdk": "7.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.2",
-          "NotificationApi.Client": "1.49.2",
-          "System.IdentityModel.Tokens.Jwt": "6.25.0",
-          "TimeZoneConverter": "3.3.0",
-          "UserApi.Client": "1.45.2",
-          "VideoApi.Client": "1.48.6"
+          "BookingQueueSubscriber.Common": "[1.0.0, )",
+          "BookingsApi.Client": "[1.46.10, )",
+          "LaunchDarkly.ServerSdk": "[7.0.3, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[6.0.2, )",
+          "NotificationApi.Client": "[1.49.2, )",
+          "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
+          "TimeZoneConverter": "[3.3.0, )",
+          "UserApi.Client": "[1.45.2, )",
+          "VideoApi.Client": "[1.50.1-pr-0627-0002, )"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
@@ -2302,8 +2302,8 @@
       },
       "VideoApi.Client": {
         "type": "Transitive",
-        "resolved": "1.50.1-pr-0627-0002",
-        "contentHash": "DvfZPCdbnVAaAkx9Pn2oYcxI6kl4shLeq7j/k/642N5XSO4/l5yiWluN9lHlmkizCpQSiCSnXiDkoVDzkHI87Q==",
+        "resolved": "1.50.1",
+        "contentHash": "OJqOqsRFAdxGyHVfrj6zo7GdGl/aVXAoLl0EpiWnwbU+2wAIwzicI8u5TwxahmeG8Gjtji7SHx3x/A4n0WWOPQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2342,7 +2342,7 @@
           "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
           "TimeZoneConverter": "[3.3.0, )",
           "UserApi.Client": "[1.45.2, )",
-          "VideoApi.Client": "[1.50.1-pr-0627-0002, )"
+          "VideoApi.Client": "[1.50.1, )"
         }
       }
     }

--- a/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
+++ b/BookingQueueSubscriber/BookingQueueSubscriber/packages.lock.json
@@ -2302,8 +2302,8 @@
       },
       "VideoApi.Client": {
         "type": "Transitive",
-        "resolved": "1.48.6",
-        "contentHash": "Q0ULqmgAbKWqlV1/Vv/NikKXGQMTLyvJxx5dm+VPBMtS9Fokt2rtDlBiAJDLX7A81UxXj/SU0evQ43IoiU8oUw==",
+        "resolved": "1.50.1-pr-0627-0002",
+        "contentHash": "DvfZPCdbnVAaAkx9Pn2oYcxI6kl4shLeq7j/k/642N5XSO4/l5yiWluN9lHlmkizCpQSiCSnXiDkoVDzkHI87Q==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -2320,29 +2320,29 @@
       "bookingqueuesubscriber.common": {
         "type": "Project",
         "dependencies": {
-          "BookingsApi.Client": "1.46.10",
-          "LaunchDarkly.ServerSdk": "7.0.3",
-          "Microsoft.ApplicationInsights": "2.21.0",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
-          "Microsoft.Extensions.Configuration.Json": "6.0.0",
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
-          "Newtonsoft.Json": "13.0.1",
-          "VH.Core.Configuration": "0.1.13"
+          "BookingsApi.Client": "[1.46.10, )",
+          "LaunchDarkly.ServerSdk": "[7.0.3, )",
+          "Microsoft.ApplicationInsights": "[2.21.0, )",
+          "Microsoft.Azure.Functions.Extensions": "[1.1.0, )",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[6.0.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "[5.2.9, )",
+          "Newtonsoft.Json": "[13.0.1, )",
+          "VH.Core.Configuration": "[0.1.13, )"
         }
       },
       "bookingqueuesubscriber.services": {
         "type": "Project",
         "dependencies": {
-          "BookingQueueSubscriber.Common": "1.0.0",
-          "BookingsApi.Client": "1.46.10",
-          "LaunchDarkly.ServerSdk": "7.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.2",
-          "NotificationApi.Client": "1.49.2",
-          "System.IdentityModel.Tokens.Jwt": "6.25.0",
-          "TimeZoneConverter": "3.3.0",
-          "UserApi.Client": "1.45.2",
-          "VideoApi.Client": "1.48.6"
+          "BookingQueueSubscriber.Common": "[1.0.0, )",
+          "BookingsApi.Client": "[1.46.10, )",
+          "LaunchDarkly.ServerSdk": "[7.0.3, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[6.0.2, )",
+          "NotificationApi.Client": "[1.49.2, )",
+          "System.IdentityModel.Tokens.Jwt": "[6.25.0, )",
+          "TimeZoneConverter": "[3.3.0, )",
+          "UserApi.Client": "[1.45.2, )",
+          "VideoApi.Client": "[1.50.1-pr-0627-0002, )"
         }
       }
     }

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -3,14 +3,13 @@ java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-627.dev.platform.hmcts.net/
-    QUEUENAME: oliver-booking
+    QUEUENAME: booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: oliver-booking
+    queueName: booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -3,13 +3,14 @@ java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    QUEUENAME: booking
+    VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-627.dev.platform.hmcts.net/
+    QUEUENAME: oliver-booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: booking
+    queueName: oliver-booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10390


### Change description ###
When a new user is created, we need to call video api to update their username in the database.
Instead of calling the API to update the whole participant, call a new endpoint to just update the username. This way the linked participants won't be deleted from them not being present in the update request.
