### PR TITLE
VIH-10426 Fix - reassigned judiciary judge cannot start hearing

### DIFF
--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/Mappers/ParticipantToParticipantRequestMapper.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/Mappers/ParticipantToParticipantRequestMapper.cs
@@ -29,5 +29,13 @@ namespace BookingQueueSubscriber.Services.Mappers
             
             return request;
         }
+
+        public static ParticipantRequest MapToParticipantRequest(ParticipantDto participant, Guid participantId, Guid participantRefId)
+        {
+            var request = MapToParticipantRequest(participant);
+            request.Id = participantId;
+            request.ParticipantRefId = participantRefId;
+            return request;
+        }
     }
 }

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/ParticipantsAddedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/ParticipantsAddedHandler.cs
@@ -2,6 +2,7 @@ using BookingQueueSubscriber.Services.Mappers;
 using BookingQueueSubscriber.Services.VideoApi;
 using BookingQueueSubscriber.Services.VideoWeb;
 using VideoApi.Contract.Requests;
+using VideoApi.Contract.Responses;
 
 namespace BookingQueueSubscriber.Services.MessageHandlers
 {
@@ -31,18 +32,51 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
 
             await _videoApiService.AddParticipantsToConference(conference.Id, request);
 
+            conference = await _videoApiService.GetConferenceByHearingRefId(eventMessage.Hearing.HearingId);
+            var newParticipants = ExtractNewParticipants(conference, eventMessage);
+
             var updateConferenceParticipantsRequest = new UpdateConferenceParticipantsRequest
             {
-                NewParticipants =
-                    eventMessage.Participants.Select(ParticipantToParticipantRequestMapper.MapToParticipantRequest).ToList(),
+                NewParticipants = newParticipants.ToList()
             };
             await _videoWebService.PushParticipantsUpdatedMessage(conference.Id, updateConferenceParticipantsRequest);
+        }
+
+        private static IEnumerable<ParticipantRequest> ExtractNewParticipants(ConferenceDetailsResponse conference, 
+            ParticipantsAddedIntegrationEvent eventMessage)
+        {
+            var addedParticipants = conference.Participants
+                .Where(participant => eventMessage.Participants.Any(p => p.ParticipantId == participant.RefId))
+                .ToList();
+
+            var newParticipants = new List<ParticipantRequest>();
+            var eventMessageParticipants = eventMessage.Participants.ToList();
+            
+            foreach (var eventMessageParticipant in eventMessageParticipants)
+            {
+                var participantId = eventMessageParticipant.ParticipantId;
+                var participantRefId = eventMessageParticipant.ParticipantId;
+                
+                var participant = addedParticipants.SingleOrDefault(x => x.RefId == eventMessageParticipant.ParticipantId);
+                if (participant != null)
+                {
+                    participantId = participant.Id;
+                    participantRefId = participant.RefId;
+                }
+                
+                var newParticipant = ParticipantToParticipantRequestMapper.MapToParticipantRequest(eventMessageParticipant, participantId, participantRefId);
+                newParticipants.Add(newParticipant);
+            }
+
+            return newParticipants;
         }
 
         async Task IMessageHandler.HandleAsync(object integrationEvent)
         {
             await HandleAsync((ParticipantsAddedIntegrationEvent)integrationEvent);
         }
+
+        
     }
 
 

--- a/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/ParticipantsAddedHandler.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.Services/MessageHandlers/ParticipantsAddedHandler.cs
@@ -75,8 +75,6 @@ namespace BookingQueueSubscriber.Services.MessageHandlers
         {
             await HandleAsync((ParticipantsAddedIntegrationEvent)integrationEvent);
         }
-
-        
     }
 
 

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/Mappers/ParticipantToParticipantRequestMapperTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/Mappers/ParticipantToParticipantRequestMapperTests.cs
@@ -77,6 +77,45 @@ namespace BookingQueueSubscriber.UnitTests.Mappers
             linkedParticipant.LinkedRefId.Should().Be(participantDto.LinkedParticipants[0].LinkedId);
             linkedParticipant.ParticipantRefId.Should().Be(participantDto.LinkedParticipants[0].ParticipantId);
         }
+
+        [Test]
+        public void should_map_participant_dto_with_participant_id_and_participant_ref_id_overloads_to_participant_request()
+        {
+            var participantDto = CreateParticipantDtoWithLinkedParticipants();
+
+            var participantId = Guid.NewGuid();
+            var participantRefId = Guid.NewGuid();
+            var request = ParticipantToParticipantRequestMapper.MapToParticipantRequest(participantDto, participantId, participantRefId);
+            
+            request.Should().NotBeNull();
+            request.Should().BeEquivalentTo(participantDto, options => 
+                options
+                    .Excluding(o => o.ParticipantId)
+                    .Excluding(o => o.Fullname)
+                    .Excluding(o => o.UserRole)
+                    .Excluding(o => o.CaseGroupType)
+                    .Excluding(o => o.Representee)
+                    .Excluding(o => o.LinkedParticipants)
+                    .Excluding(o => o.ContactEmailForNonEJudJudgeUser)
+                    .Excluding(o => o.ContactPhoneForNonEJudJudgeUser)
+                    .Excluding(o => o.SendHearingNotificationIfNew)
+            );
+            request.Id.Should().Be(participantId);
+            request.ParticipantRefId.Should().Be(participantRefId);
+            request.Name.Should().Be(participantDto.Fullname);
+            request.FirstName.Should().Be(participantDto.FirstName);
+            request.LastName.Should().Be(participantDto.LastName);
+            request.ContactEmail.Should().Be(participantDto.ContactEmail);
+            request.ContactTelephone.Should().Be(participantDto.ContactTelephone);
+            request.UserRole.ToString().Should().Be(participantDto.UserRole);
+            request.HearingRole.Should().Be(participantDto.HearingRole);
+            request.CaseTypeGroup.Should().Be(participantDto.CaseGroupType.ToString());
+            request.Representee.Should().Be(participantDto.Representee);
+            var linkedParticipant = request.LinkedParticipants.First();
+            linkedParticipant.Type.Should().Be(LinkedParticipantType.Interpreter);
+            linkedParticipant.LinkedRefId.Should().Be(participantDto.LinkedParticipants[0].LinkedId);
+            linkedParticipant.ParticipantRefId.Should().Be(participantDto.LinkedParticipants[0].ParticipantId);
+        }
         
         private static ParticipantDto CreateParticipantDtoWithoutLinkedParticipants()
         {

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/ParticipantsAddedHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/ParticipantsAddedHandlerTests.cs
@@ -189,7 +189,7 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
             };
         }
 
-        private IList<LinkedParticipantRequest> MapToRequestFromDto(IList<LinkedParticipantDto> linked)
+        private static IList<LinkedParticipantRequest> MapToRequestFromDto(IList<LinkedParticipantDto> linked)
         {
             return linked.Select(l => new LinkedParticipantRequest()
             {

--- a/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/ParticipantsAddedHandlerTests.cs
+++ b/BookingQueueSubscriber/BookingQueueSubscriber.UnitTests/MessageHandlers/ParticipantsAddedHandlerTests.cs
@@ -21,7 +21,24 @@ namespace BookingQueueSubscriber.UnitTests.MessageHandlers
             var integrationEvent = GetIntegrationEvent();
             await messageHandler.HandleAsync(integrationEvent);
             VideoApiServiceMock.Verify(x => x.AddParticipantsToConference(It.IsAny<Guid>(), It.IsAny<AddParticipantsToConferenceRequest>()), Times.Once);
-            VideoWebServiceMock.Verify(x => x.PushParticipantsUpdatedMessage(It.IsAny<Guid>(), It.IsAny<UpdateConferenceParticipantsRequest>()), Times.Once);
+            VideoWebServiceMock.Verify(x => x.PushParticipantsUpdatedMessage(
+                ConferenceDetailsResponse.Id, 
+                It.Is<UpdateConferenceParticipantsRequest>(r => 
+                    r.NewParticipants[0].Id == ConferenceDetailsResponse.Participants[0].Id && 
+                    r.NewParticipants[0].Name == integrationEvent.Participants[0].Fullname &&
+                    r.NewParticipants[0].Username == integrationEvent.Participants[0].Username &&
+                    r.NewParticipants[0].FirstName == integrationEvent.Participants[0].FirstName &&
+                    r.NewParticipants[0].LastName == integrationEvent.Participants[0].LastName &&
+                    r.NewParticipants[0].ContactEmail == integrationEvent.Participants[0].ContactEmail &&
+                    r.NewParticipants[0].ContactTelephone == integrationEvent.Participants[0].ContactTelephone &&
+                    r.NewParticipants[0].DisplayName == integrationEvent.Participants[0].DisplayName &&
+                    r.NewParticipants[0].UserRole.ToString() == integrationEvent.Participants[0].UserRole &&
+                    r.NewParticipants[0].HearingRole == integrationEvent.Participants[0].HearingRole &&
+                    r.NewParticipants[0].CaseTypeGroup == integrationEvent.Participants[0].CaseGroupType.ToString() &&
+                    r.NewParticipants[0].ParticipantRefId == ConferenceDetailsResponse.Participants[0].RefId &&
+                    r.NewParticipants[0].Representee == integrationEvent.Participants[0].Representee &&
+                    r.NewParticipants[0].LinkedParticipants.Count.Equals(0)
+            )), Times.Once());
         }
 
         [Test]

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -3,13 +3,13 @@ java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    QUEUENAME: booking
+    QUEUENAME: oliver-booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: booking
+    queueName: oliver-booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'

--- a/charts/vh-booking-queue-subscriber/values.dev.template.yaml
+++ b/charts/vh-booking-queue-subscriber/values.dev.template.yaml
@@ -3,13 +3,13 @@ java:
   image: '${IMAGE_NAME}'
   releaseNameOverride: ${RELEASE_NAME}
   environment:
-    QUEUENAME: oliver-booking
+    QUEUENAME: booking
 function:
   releaseNameOverride: ${RELEASE_NAME}
   triggers:
   - type: azure-servicebus 
     serviceBusName: "vh-infra-core-dev"
-    queueName: oliver-booking
+    queueName: booking
     messageCount: 1
   object:
     name: '${RELEASE_NAME}'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10426


### Change description ###
Fixes an issue where if the judiciary judge is changed (V2) the new judge can't start the hearing in video web without refreshing the page.

The cause is the `ParticipantsUpdatedMessage` published to video web from the `ParticipantsAddedHandler`. It contains the wrong participant id (mapped to the ParticipantRefId instead of the ParticipantId) so video web can't find the current user and so sends them to the panel member waiting room instead of the judge waiting room. Since this participant is retrieved from the conference cache, it is eventually resolved by the user refreshing the page and subsequently refreshing the cache.

Fix by retrieving the participant id from video api after the participant has been added and sending it in the message.